### PR TITLE
Add hero and callout components

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -14,6 +14,7 @@
     { "title": "Advanced", "path": "/advanced" },
     { "title": "Community", "path": "/community" },
     { "title": "Migration", "path": "/migration" },
-    { "title": "Architecture", "path": "/architectural-sketches-detailed/phase1/dev_server_architecture" }
+    { "title": "Architecture", "path": "/architectural-sketches-detailed/phase1/dev_server_architecture" },
+    { "title": "Components", "path": "/components" }
   ]
 }

--- a/docs-site/pages/components.mdx
+++ b/docs-site/pages/components.mdx
@@ -1,0 +1,21 @@
+# Component Showcase
+
+<Card>
+<CardHeader>
+<CardTitle>Accordion & Tabs</CardTitle>
+<CardDescription>Examples of the custom components.</CardDescription>
+</CardHeader>
+<CardContent>
+  <Accordion title="What is FARM?">
+    FARM is an AI-first full stack framework.
+  </Accordion>
+  <Tabs defaultValue="one" className="mt-6">
+    <TabsList>
+      <TabsTrigger value="one">One</TabsTrigger>
+      <TabsTrigger value="two">Two</TabsTrigger>
+    </TabsList>
+    <TabsContent value="one">First tab content</TabsContent>
+    <TabsContent value="two">Second tab content</TabsContent>
+  </Tabs>
+</CardContent>
+</Card>

--- a/docs-site/pages/index.mdx
+++ b/docs-site/pages/index.mdx
@@ -1,6 +1,12 @@
 # FARM Stack Framework
 
-## AI-First Full-Stack Development Platform
+<Hero />
+
+<Card className="my-8">
+<CardContent>
+Welcome to the FARM documentation. Explore the guide using the sidebar.
+</CardContent>
+</Card>
 
 ### Table of Contents
 
@@ -24,6 +30,10 @@
 ### Vision Statement
 
 The FARM Stack Framework is a general-purpose, AI-first full-stack development platform that seamlessly integrates React/TypeScript frontends with Python/FastAPI backends, optimized for modern AI/ML workloads. It provides the developer experience quality of Next.js while bridging the gap between web development's most powerful frontend ecosystem (React) and AI/ML's most advanced backend ecosystem (Python).
+
+<Callout type="tip" title="Why FARM?">
+  Build once, deploy anywhere with a unified AI-first toolchain.
+</Callout>
 
 ### Core Value Proposition
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
+    <title>FARM Documentation</title>
   </head>
   <body class="min-h-screen bg-background font-sans antialiased">
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@mdx-js/react": "^3.1.0",
     "@mdx-js/rollup": "^3.1.0",
+    "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@mdx-js/rollup':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.14.1)(rollup@4.42.0)
+      '@radix-ui/colors':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.11
         version: 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -573,6 +576,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@radix-ui/colors@3.0.0':
+    resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -3138,6 +3144,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@radix-ui/colors@3.0.0': {}
 
   '@radix-ui/number@1.1.1': {}
 

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,0 +1,20 @@
+import {
+  Accordion as AccordionRoot,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+
+export default function Accordion({ title, children }: { title: string; children: React.ReactNode }) {
+  const value = title.toLowerCase().replace(/\s+/g, "-");
+  return (
+    <AccordionRoot type="single" collapsible className="w-full">
+      <AccordionItem value={value}>
+        <AccordionTrigger>{title}</AccordionTrigger>
+        <AccordionContent>{children}</AccordionContent>
+      </AccordionItem>
+    </AccordionRoot>
+  );
+}
+
+export { AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -1,0 +1,33 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Info, AlertTriangle, Lightbulb } from "lucide-react";
+
+type CalloutType = "info" | "warning" | "tip";
+
+export default function Callout({
+  type = "info",
+  title,
+  children,
+}: {
+  type?: CalloutType;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  const icon =
+    type === "info" ? (
+      <Info />
+    ) : type === "warning" ? (
+      <AlertTriangle />
+    ) : (
+      <Lightbulb />
+    );
+
+  const variant = type === "warning" ? "destructive" : "default";
+
+  return (
+    <Alert variant={variant} className="my-4">
+      {icon}
+      {title && <AlertTitle>{title}</AlertTitle>}
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,9 @@
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@/components/ui/button";
+import { H1, Lead } from "@/components/ui/typography";
+
+export default function Hero() {
+  return (
+    <section className="py-16 text-center space-y-4">
+      <H1 className="text-5xl">FARM Stack Framework</H1>
+      <Lead className="max-w-2xl mx-auto">
+        AI-first full-stack development platform built with React and FastAPI.
+      </Lead>
+      <div className="flex justify-center gap-4 pt-4">
+        <Button asChild>
+          <a href="/guide/getting-started">Get Started</a>
+        </Button>
+        <Button variant="outline" asChild>
+          <a href="https://github.com" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,1 @@
+export { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,10 @@
+import { Tooltip as UITooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+export default function Tooltip({ tip, children }: { tip: string; children: React.ReactNode }) {
+  return (
+    <UITooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{tip}</TooltipContent>
+    </UITooltip>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
 
 @custom-variant dark (&:is(.dark *));
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -123,11 +124,14 @@
 }
 
 @layer base {
+  html {
+    scroll-behavior: smooth;
+  }
   * {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 pre {

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -2,6 +2,7 @@ import "../index.css";
 import type { ReactNode } from "react";
 import Sidebar from "../components/Sidebar";
 import CopyPageButton from "../components/CopyPageButton";
+import { ModeToggle } from "../components/mode-toggle";
 import { useLocation } from "react-router-dom";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -12,17 +13,23 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     .map((p) => p.replace(/-/g, " "))
     .join(" / ") || "Home";
   return (
-    <div className="min-h-screen flex">
-      <Sidebar />
-      <main className="flex-1 px-6 py-8">
-        <div className="mx-auto max-w-3xl prose lg:prose-lg dark:prose-invert">
-          <div className="mb-6 flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">{breadcrumb}</span>
-            <CopyPageButton />
-          </div>
-          {children}
+    <div className="min-h-screen flex flex-col">
+      <header className="border-b px-6 py-4 flex items-center justify-between">
+        <span className="font-semibold">FARM Docs</span>
+        <div className="flex gap-2">
+          <ModeToggle />
+          <CopyPageButton />
         </div>
-      </main>
+      </header>
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 px-6 py-8">
+          <div className="mx-auto max-w-3xl prose lg:prose-lg dark:prose-invert">
+            <div className="mb-6 text-sm text-muted-foreground">{breadcrumb}</div>
+            {children}
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,12 @@ import App from './App.tsx'
 import { ThemeProvider } from './components/theme-provider'
 import { MDXProvider } from '@mdx-js/react'
 import CodeBlock from './components/CodeBlock'
+import Tooltip from './components/Tooltip'
+import Callout from './components/Callout'
+import Hero from './components/Hero'
+import Accordion from './components/Accordion'
+import * as Tabs from './components/Tabs'
+import * as Card from './components/Card'
 import * as Typography from './components/ui/typography'
 
 createRoot(document.getElementById('root')!).render(
@@ -16,6 +22,12 @@ createRoot(document.getElementById('root')!).render(
           code: Typography.InlineCode,
           a: Typography.A,
           hr: Typography.Hr,
+          Tooltip,
+          Callout,
+          Hero,
+          Accordion,
+          ...Tabs,
+          ...Card,
           ...Typography,
         }}
       >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from 'tailwindcss'
+import { slate, slateDark, blue, blueDark } from '@radix-ui/colors'
+import typography from '@tailwindcss/typography'
 
 export default {
   darkMode: 'class',
@@ -17,6 +19,9 @@ export default {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
       borderRadius: {
         sm: 'var(--radius-sm)',
         md: 'var(--radius-md)',
@@ -24,6 +29,10 @@ export default {
         xl: 'var(--radius-xl)',
       },
       colors: {
+        ...slate,
+        ...slateDark,
+        ...blue,
+        ...blueDark,
         background: 'var(--color-background)',
         foreground: 'var(--color-foreground)',
         card: 'var(--color-card)',
@@ -53,5 +62,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [typography],
 } satisfies Config


### PR DESCRIPTION
## Summary
- add Tailwind typography plugin and Inter font
- rework global CSS and head to load font
- add Accordion, Tabs and Card components
- map new components in MDX provider
- add components page and link in nav
- showcase components on the homepage

## Testing
- `npm run lint` *(warnings only)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68457f61a82483238fb9f33830456482